### PR TITLE
Issue with CreateMaxDimensionNoOrientation

### DIFF
--- a/src/main/java/com/mortennobel/imagescaling/DimensionConstrain.java
+++ b/src/main/java/com/mortennobel/imagescaling/DimensionConstrain.java
@@ -145,7 +145,7 @@ public class DimensionConstrain {
 				int width;
 				int height;
 				// swap length1 and length2
-				if (srcScaleFactor>scaleFactor){
+				if (srcScaleFactor>=scaleFactor){
 					width = length1;
 					height = length2;
 				}

--- a/src/test/java/com/mortennobel/imagescaling/DimensionConstrainTest.java
+++ b/src/test/java/com/mortennobel/imagescaling/DimensionConstrainTest.java
@@ -70,6 +70,17 @@ public class DimensionConstrainTest {
 	}
 
 
+	@Test
+	public void testCreateMaxDimensionNoOrientationSameScaleFactor1(){
+		DimensionConstrain constains = createMaxDimensionNoOrientation(400,200,true);
+		Dimension res = constains.getDimension(new Dimension(600,300));
+		assertEquals(new Dimension(400,200),res);
+	}
 
-
+	@Test
+	public void testCreateMaxDimensionNoOrientationSameScaleFactor2(){
+		DimensionConstrain constains = createMaxDimensionNoOrientation(400,200,true);
+		Dimension res = constains.getDimension(new Dimension(300,600));
+		assertEquals(new Dimension(200,400),res);
+	}
 }


### PR DESCRIPTION
When the dimension to be tested has the same scale factor than the defined DimensionConstrain, the function CreateMaxDimensionNoOrientation do an unecessary switch between length1 and length2. As result, the new dimension is not expected.

(previous pull request is a mess and i don't know how to remove it by myself. sorry, i'm a newbie here)